### PR TITLE
Make the pycparser_utils_path var get path automatically

### DIFF
--- a/src/backend/generate_executable.py
+++ b/src/backend/generate_executable.py
@@ -1,8 +1,9 @@
 from pycparser import parse_file, c_generator
 from pycparser.c_ast import FuncDef, Decl, FuncCall, ID, Compound, TypeDecl, IdentifierType, FuncDecl, ParamList, Return, Constant, Assignment, ExprList, BinaryOp, NamedInitializer, InitList, Struct, ArrayDecl, Cast, Typename
 import os
+import pycparser_fake_libc
 
-pycparser_utils_path = '/Users/abdallaeltayeb/Desktop/Gamtime_project/pycparser/utils/fake_libc_include'
+pycparser_utils_path = pycparser_fake_libc.directory
 
 class ExecutableTransformer(object):
     """ 


### PR DESCRIPTION
The pycparser_utils_path variable now gets the path form the import's .directory. There is no more need to move the fake_libc_parser package to the root directory. 