### PR TITLE
Fix endianness

### DIFF
--- a/src/backend/generate_executable.py
+++ b/src/backend/generate_executable.py
@@ -282,7 +282,8 @@ class ExecutableTransformer(object):
         """
         generator = c_generator.CGenerator()
         type_str = generator.visit(type_node)
-        return f"{type_str} {name} = {value};"
+        # Use __builtin_bswap32 to convert KLEE's little endian value to big endian.
+        return f"{type_str} {name} = __builtin_bswap32({value});"
 
     def generate_struct_declaration(self, name, struct_type_node, value_dict):
         """


### PR DESCRIPTION
This PR converts KLEE's little endian representation to big endian when used in `driver.c`